### PR TITLE
Add TextStyle to CodeTextView to remove the need for a CompositionLocalProvider

### DIFF
--- a/kodeview/src/commonMain/kotlin/dev/snipme/kodeview/view/CodeTextView.kt
+++ b/kodeview/src/commonMain/kotlin/dev/snipme/kodeview/view/CodeTextView.kt
@@ -15,13 +15,15 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextStyle
 import dev.snipme.highlights.Highlights
 import generateAnnotatedString
 
 @Composable
 fun CodeTextView(
     modifier: Modifier = Modifier.background(Color.Transparent),
-    highlights: Highlights
+    highlights: Highlights,
+    textStyle: TextStyle = TextStyle.Default
 ) {
     var textState by remember {
         mutableStateOf(AnnotatedString(highlights.getCode()))
@@ -41,7 +43,8 @@ fun CodeTextView(
             modifier = modifier
                 .verticalScroll(rememberScrollState())
                 .horizontalScroll(rememberScrollState()),
-            text = textState
+            text = textState,
+            style = textStyle
         )
     }
 }


### PR DESCRIPTION
Removed the need to wrap the code in a `CodeTextView` in a `CompositionLocalProvider` if you need a local text style like I want to in my project. So for example you could replace this:
```kotlin
CompositionLocalProvider(
    LocalTextStyle provides TextStyle(
        fontSize = 22.sp,
        textAlign = TextAlign.Start,
        fontFamily = FontFamily(theme.codeFontFamily.map { Font(it) })
    )
) {
    CodeTextView(
        modifier = modifier
            .background(theme.colourScheme.primaryContainer)
            .padding(8.dp),
        highlights = it,
        textStyle=TextStyle(
            fontSize = 22.sp,
            textAlign = TextAlign.Start,
            fontFamily = FontFamily(theme.codeFontFamily.map { Font(it) }
        )
    )
}
```
With this:

```kotlin
CodeTextView(
    modifier = modifier
        .background(theme.colourScheme.primaryContainer)
        .padding(8.dp),
    highlights = it,
    textStyle=TextStyle(
        fontSize = 22.sp,
        textAlign = TextAlign.Start,
        fontFamily = FontFamily(theme.codeFontFamily.map { Font(it) }
    )
)
```
Lmk if you have any questions!